### PR TITLE
Fix: Pricing Cards Getting Cut Off

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -915,6 +915,7 @@ h1, h2, h3, h4, h5, h6 {
     position: relative;
     z-index: 10;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
+    margin-bottom: 40px;
 }
 
 .form-switch .form-check-input {
@@ -939,11 +940,12 @@ h1, h2, h3, h4, h5, h6 {
 
 .pricing-card.popular {
     border: 2px solid var(--accent);
-    transform: scale(1.05);
+    transform: scale(1.02); 
+    margin: 0 10px; 
 }
 
 .pricing-card.popular:hover {
-    transform: scale(1.05) translateY(-10px);
+    transform: scale(1.02) translateY(-10px); 
 }
 
 .popular-badge {


### PR DESCRIPTION
### Description
This PR resolves the issue where the pricing cards were getting cut off at the bottom of the page.

### Changes Made
- Added `margin-bottom: 40px;` to `.pricing-toggle` class in the CSS

### Why It Works
The additional bottom margin creates the necessary spacing, preventing layout clipping and ensuring all cards are fully visible.

---

### 📸 Screenshot (After)
<img width="1440" alt="Screenshot 2025-05-31 at 1 44 26 PM" src="https://github.com/user-attachments/assets/bbeb0e09-d295-4c93-a7b2-26004e7a48ce" />


### Related Issue
Closes #6 



